### PR TITLE
[WIP] Add compiler pass that auto register repositories in the container

### DIFF
--- a/DependencyInjection/Compiler/RepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/RepositoryCompilerPass.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Theodo\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * RepositoryCompilerPass
+ * 
+ * @author Benjamin Grandfond <benjaming@theodo.fr>
+ */
+class RepositoryCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getServiceIds() as $service) {
+            // Look for entity managers
+            if (strpos($service, '_entity_manager') == false) {
+                continue;
+            }
+
+            /** @var \Doctrine\ORM\EntityManager */
+            $em = $container->get($service);
+
+            if (!is_a($em, 'Doctrine\ORM\EntityManager')) {
+                continue;
+            }
+
+            $entities = $em->getConfiguration()
+                ->getMetadataDriverImpl()
+                ->getAllClassNames();
+
+            foreach ($entities as $entity) {
+                $this->registerRepository($entity, $service, $container);
+            }
+        }
+    }
+
+    /**
+     * @param $entityClassName
+     * @param $emServiceId
+     * @param ContainerBuilder $container
+     */
+    private function registerRepository($entityClassName, $emServiceId, ContainerBuilder $container)
+    {
+        $em = $container->get($emServiceId);
+        $metadata = $em->getClassMetadata($entityClassName);
+        $repositoryClassName = $metadata->customRepositoryClassName ?: 'Doctrine\ORM\EntityRepository';
+
+        $container->setDefinition(
+            $this->createId($repositoryClassName),
+            $this->createDefinition($repositoryClassName, $entityClassName, $emServiceId));
+    }
+
+    /**
+     * Generate an id for the repository service
+     *
+     * @param $repositoryClassName
+     * @return string
+     *
+     * @todo : add the bundle name before
+     */
+    private function createId($repositoryClassName)
+    {
+        $parts = explode('\\', $repositoryClassName);
+        $className = end($parts);
+
+        return 'repository.' . Container::underscore($className);
+    }
+
+    /**
+     * Create a service definition for a repository class.
+     *
+     * @param  $repository The repository class name
+     * @param  $entity     The entity class name
+     * @param  $manager    The entity manager service id
+     * @return Definition
+     */
+    private function createDefinition($repository, $entity, $manager)
+    {
+        $definition = new Definition($repository);
+        $definition->setFactoryService($manager);
+        $definition->setFactoryMethod("getRepository");
+        $definition->addArgument($entity);
+
+        return $definition;
+    }
+}

--- a/Tests/DependencyInjection/CompilerPass/RepositoryCompilerPassTest.php
+++ b/Tests/DependencyInjection/CompilerPass/RepositoryCompilerPassTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Theodo\Bundle\FrameworkExtraBundle\Tests\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Definition;
+use Theodo\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\RepositoryCompilerPass;
+
+/**
+ * RepositoryCompilerPassTest
+ * 
+ * @author Benjamin Grandfond <benjaming@theodo.fr>
+ */
+class RepositoryCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldRegisterEveryRepositoryAsAService()
+    {
+        $driver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver', array('loadMetadataForClass', 'getAllClassNames', 'isTransient'));
+        $driver->expects($this->once())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array('Foo\Entity\Bar')))
+        ;
+
+        $config = $this->getMock('Doctrine\ORM\Configuration', array('getMetadataDriverImpl'));
+        $config->expects($this->once())
+            ->method('getMetadataDriverImpl')
+            ->will($this->returnValue($driver))
+        ;
+
+        $metadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getConfiguration', 'getClassMetadata'))
+            ->getMock()
+        ;
+        $em->expects($this->once())
+            ->method('getConfiguration')
+            ->will($this->returnValue($config))
+        ;
+        $em->expects($this->once())
+            ->method('getClassMetadata')
+            ->will($this->returnValue($metadata))
+        ;
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getServiceIds', 'get', 'setDefinition'))
+            ->getMock()
+        ;
+
+        $emId = 'doctrine.orm.default_entity_manager';
+
+        $container->expects($this->once())
+            ->method('getServiceIds')
+            ->will($this->returnValue(array($emId)))
+        ;
+
+        $container->expects($this->exactly(2))
+            ->method('get')
+            ->with($emId)
+            ->will($this->returnValue($em))
+        ;
+
+        $container->expects($this->atLeastOnce())
+            ->method('setDefinition')
+            ->with(
+                $this->isType('string'),
+                $this->isInstanceOf('Symfony\Component\DependencyInjection\Definition')
+            )
+        ;
+
+        $compilerPass = new RepositoryCompilerPass();
+        $compilerPass->process($container);
+    }
+}
+ 

--- a/TheodoFrameworkExtraBundle.php
+++ b/TheodoFrameworkExtraBundle.php
@@ -2,7 +2,10 @@
 
 namespace Theodo\Bundle\FrameworkExtraBundle;
 
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Theodo\Bundle\FrameworkExtraBundle\DependencyInjection\Compiler\RepositoryCompilerPass;
 
 /**
  * TheodoFrameworkExtraBundle
@@ -11,4 +14,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class TheodoFrameworkExtraBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RepositoryCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);
+    }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "symfony/framework-bundle": ">=2.1.0,<3.0",
         "doctrine/orm": "~2.2,>=2.2.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "minimum-stability": "dev",
     "target-dir": "Theodo/Bundle/FrameworkExtraBundle",
     "autoload": {


### PR DESCRIPTION
This PR adds a compiler pass that is able to register a repository as repository for each entity that doctrine is aware of. If no repository is specified for an entity then it uses the `Doctrine\ORM\EntityRepository`.
## Usage

Given a place entity is defined:

``` php

namespace Foo\Bundle\BarBundle\Entity;

use Doctrine\ORM\Mapping as ORM;

/**
 * @ORM\Entity(repositoryClass="Foo\Bundle\BarBundle\Repository\PlaceRepository")
 */
class Place
{
    /** @ORM\Id() */
    private $id;

    /** @ORM\Column(type="string", length=255) */
    private $name;
}
```

And the `TheodoFrameworkExtraBundle` is registered in `AppKernel.php`
When I call the service `$container->get('repository.place_repository')`
Then it should return an instance of `Foo\Bundle\BarBundle\Repository\PlaceRepository` class
## Todo
- [ ] Add the bundle (or the namespace) in the id of the service to avoid naming collision (e.g foo_bar_bundle.repository.place or foo_bar.repository.place)
